### PR TITLE
hotfix: inject script for iframe resize

### DIFF
--- a/packages/runtime/src/microapp-message-bus.ts
+++ b/packages/runtime/src/microapp-message-bus.ts
@@ -5,6 +5,7 @@ export type MicroappMessageTypes =
       '@microapp:userPreferences',
       { theme?: string; lang?: string }
     >
-  | WindowMessage<'@microapp:routeChange', { route: string }>;
+  | WindowMessage<'@microapp:routeChange', { route: string }>
+  | WindowMessage<'@microapp:resize', { height: number }>;
 
 export class MicroappMessageBus extends WindowPostMessageBus<MicroappMessageTypes> {}

--- a/packages/runtime/src/microapp.tsx
+++ b/packages/runtime/src/microapp.tsx
@@ -36,6 +36,10 @@ export const Microapp: React.FC<MicroappProps> = ({
             url,
             theme,
             lang,
+            onLoad: () => {
+              onLoad?.();
+              setIsLoading(false);
+            },
           });
           setIsLoading(false);
         } else {
@@ -45,8 +49,6 @@ export const Microapp: React.FC<MicroappProps> = ({
             lang,
           });
         }
-
-        onLoad?.();
       } catch (error) {
         setIsLoading(false);
         onError?.(
@@ -66,6 +68,7 @@ export const Microapp: React.FC<MicroappProps> = ({
         style={{
           border: 'none',
         }}
+        seamless={true}
         {...rest}
       />
       {isLoading ? (


### PR DESCRIPTION
The main purpose of this PR is to change the logic when resizing the iframe. Initially we added a logic to get the height of the parent component so set the iframe height, but this was causing issues like double scroll. Now we have the script that gets the height of the content as set as the iframe height to prevent this issue.