### PR TITLE
hotfix: target origin for runtime

### DIFF
--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microapp-io/runtime",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/microapp-io/microapp-js.git",

--- a/packages/runtime/src/constants.ts
+++ b/packages/runtime/src/constants.ts
@@ -1,2 +1,2 @@
-export const PRODUCTION_MARKETPLACE_HOST_URL = 'https://www.microapp.io/';
+export const PRODUCTION_MARKETPLACE_HOSTNAME = 'https://www.microapp.io/';
 export const STAGING_MARKETPLACE_HOSTNAME = 'https://staging.microapp.io/';

--- a/packages/runtime/src/constants.ts
+++ b/packages/runtime/src/constants.ts
@@ -1,2 +1,2 @@
-export const PRODUCTION_MARKETPLACE_HOSTNAME = 'https://www.microapp.io/';
-export const STAGING_MARKETPLACE_HOSTNAME = 'https://staging.microapp.io/';
+export const PRODUCTION_MARKETPLACE_HOST_URL = 'https://www.microapp.io/';
+export const STAGING_MARKETPLACE_HOST_URL = 'https://staging.microapp.io/';

--- a/packages/runtime/src/constants.ts
+++ b/packages/runtime/src/constants.ts
@@ -1,1 +1,2 @@
 export const PRODUCTION_MARKETPLACE_HOST_URL = 'https://www.microapp.io/';
+export const STAGING_MARKETPLACE_HOSTNAME = 'https://staging.microapp.io/';

--- a/packages/runtime/src/microapp-runtime.ts
+++ b/packages/runtime/src/microapp-runtime.ts
@@ -1,5 +1,5 @@
 import {
-  PRODUCTION_MARKETPLACE_HOST_URL,
+  PRODUCTION_MARKETPLACE_HOSTNAME,
   STAGING_MARKETPLACE_HOSTNAME,
 } from './constants';
 import { MicroappMessageBus } from './microapp-message-bus';
@@ -33,7 +33,7 @@ export class MicroappRuntime {
 
     this.#baseRoute = window.location.pathname;
 
-    this.#targetOrigin = this.#getTargetOrigin();
+    this.#targetOrigin = this.#getAllowedTargetOriginOrThrow();
     this.#messageBus = new MicroappMessageBus({
       targetOrigin: this.#targetOrigin,
     });
@@ -83,32 +83,27 @@ export class MicroappRuntime {
     this.#updateUserPreferences();
   };
 
-  #getTargetOrigin = () => {
-    try {
-      const parentWindow = window.parent;
+  #getAllowedTargetOriginOrThrow = () => {
+    const parentWindow = window.parent;
 
-      if (!parentWindow) {
-        throw new Error(
-          'The runtime SDK should be consumed inside the marketplace'
-        );
-      }
-
-      const parentUrl = new URL(window.location.href);
-      const isParentUrlAllowed =
-        parentUrl.hostname === PRODUCTION_MARKETPLACE_HOST_URL ||
-        parentUrl.hostname === STAGING_MARKETPLACE_HOSTNAME;
-
-      // For local development you need to bypass this check
-      if (!isParentUrlAllowed) {
-        throw new Error(
-          'The runtime SDK should be consumed inside the marketplace'
-        );
-      }
-
-      return parentUrl.origin;
-    } catch (error) {
-      console.error('Error getting target origin:', error);
+    if (!parentWindow) {
+      throw new Error(
+        'The runtime SDK should be consumed inside the marketplace'
+      );
     }
+
+    const parentUrl = new URL(window.location.href);
+    const isParentUrlAllowed =
+      parentUrl.hostname === PRODUCTION_MARKETPLACE_HOSTNAME ||
+      parentUrl.hostname === STAGING_MARKETPLACE_HOSTNAME;
+
+    if (!isParentUrlAllowed) {
+      throw new Error(
+        'The runtime SDK should be consumed inside the marketplace'
+      );
+    }
+
+    return parentUrl.origin;
   };
 
   #handlePreferencesChange = ({

--- a/packages/runtime/src/microapp-runtime.ts
+++ b/packages/runtime/src/microapp-runtime.ts
@@ -1,3 +1,7 @@
+import {
+  PRODUCTION_MARKETPLACE_HOST_URL,
+  STAGING_MARKETPLACE_HOSTNAME,
+} from './constants';
 import { MicroappMessageBus } from './microapp-message-bus';
 
 type MicroappRuntimeOptions = {
@@ -14,7 +18,7 @@ export class MicroappRuntime {
   #lang: string = 'en-us';
   #baseRoute: string;
   #messageBus: MicroappMessageBus;
-  #targetOrigin: string;
+  #targetOrigin: string | undefined;
 
   constructor({
     iframeElement: iframe,
@@ -29,10 +33,9 @@ export class MicroappRuntime {
 
     this.#baseRoute = window.location.pathname;
 
-    const { origin: targetOrigin } = new URL(src);
-    this.#targetOrigin = targetOrigin;
+    this.#targetOrigin = this.#getTargetOrigin();
     this.#messageBus = new MicroappMessageBus({
-      targetOrigin,
+      targetOrigin: this.#targetOrigin,
     });
     this.#messageBus.on(
       '@microapp:userPreferences',
@@ -42,6 +45,7 @@ export class MicroappRuntime {
     this.#messageBus.on('@microapp:resize', this.#handleIframeResize);
 
     this.#updateUserPreferences();
+
     this.#iframe.addEventListener('load', () => {
       this.#injectIframeDimensionsScript();
       this.#injectRoutingScript();
@@ -77,6 +81,34 @@ export class MicroappRuntime {
     this.#baseRoute = window.location.pathname;
 
     this.#updateUserPreferences();
+  };
+
+  #getTargetOrigin = () => {
+    try {
+      const parentWindow = window.parent;
+
+      if (!parentWindow) {
+        throw new Error(
+          'The runtime SDK should be consumed inside the marketplace'
+        );
+      }
+
+      const parentUrl = new URL(window.location.href);
+      const isParentUrlAllowed =
+        parentUrl.hostname === PRODUCTION_MARKETPLACE_HOST_URL ||
+        parentUrl.hostname === STAGING_MARKETPLACE_HOSTNAME;
+
+      // For local development you need to bypass this check
+      if (!isParentUrlAllowed) {
+        throw new Error(
+          'The runtime SDK should be consumed inside the marketplace'
+        );
+      }
+
+      return parentUrl.origin;
+    } catch (error) {
+      console.error('Error getting target origin:', error);
+    }
   };
 
   #handlePreferencesChange = ({

--- a/packages/runtime/src/microapp-runtime.ts
+++ b/packages/runtime/src/microapp-runtime.ts
@@ -1,6 +1,6 @@
 import {
-  PRODUCTION_MARKETPLACE_HOSTNAME,
-  STAGING_MARKETPLACE_HOSTNAME,
+  PRODUCTION_MARKETPLACE_HOST_URL,
+  STAGING_MARKETPLACE_HOST_URL,
 } from './constants';
 import { MicroappMessageBus } from './microapp-message-bus';
 
@@ -94,8 +94,8 @@ export class MicroappRuntime {
 
     const parentUrl = new URL(window.location.href);
     const isParentUrlAllowed =
-      parentUrl.hostname === PRODUCTION_MARKETPLACE_HOSTNAME ||
-      parentUrl.hostname === STAGING_MARKETPLACE_HOSTNAME;
+      parentUrl.hostname === PRODUCTION_MARKETPLACE_HOST_URL ||
+      parentUrl.hostname === STAGING_MARKETPLACE_HOST_URL;
 
     if (!isParentUrlAllowed) {
       throw new Error(

--- a/packages/runtime/src/window-post-message-bus.ts
+++ b/packages/runtime/src/window-post-message-bus.ts
@@ -1,4 +1,4 @@
-import { PRODUCTION_MARKETPLACE_HOSTNAME } from './constants';
+import { PRODUCTION_MARKETPLACE_HOST_URL } from './constants';
 
 export type WindowMessage<
   TType extends string,
@@ -23,7 +23,7 @@ export class WindowPostMessageBus<
 
   // NB: targetOrigin is required only for sending messages.
   constructor({
-    targetOrigin = PRODUCTION_MARKETPLACE_HOSTNAME,
+    targetOrigin = PRODUCTION_MARKETPLACE_HOST_URL,
   }: { targetOrigin?: string } = {}) {
     this.#targetOrigin = targetOrigin;
     if (typeof window !== 'undefined') {

--- a/packages/runtime/src/window-post-message-bus.ts
+++ b/packages/runtime/src/window-post-message-bus.ts
@@ -1,4 +1,4 @@
-import { PRODUCTION_MARKETPLACE_HOST_URL } from './constants';
+import { PRODUCTION_MARKETPLACE_HOSTNAME } from './constants';
 
 export type WindowMessage<
   TType extends string,
@@ -23,7 +23,7 @@ export class WindowPostMessageBus<
 
   // NB: targetOrigin is required only for sending messages.
   constructor({
-    targetOrigin = PRODUCTION_MARKETPLACE_HOST_URL,
+    targetOrigin = PRODUCTION_MARKETPLACE_HOSTNAME,
   }: { targetOrigin?: string } = {}) {
     this.#targetOrigin = targetOrigin;
     if (typeof window !== 'undefined') {


### PR DESCRIPTION
This PR intends to fix the issue when consuming the runtime SDK in our test environments. We should consider the parent window for the targetOrigin. 